### PR TITLE
Added end lines for the shortcuts examples and placeholder

### DIFF
--- a/newOpt.html
+++ b/newOpt.html
@@ -28,7 +28,11 @@
 <h3>Chat text expansion shortcuts</h3>
 <div><label><input type="checkbox" id="haxShortcutConfig">Enable text expansion</label></div>
 <p><b>Example:</b> {"/e1":"/extrapolation 1","/h1":"/handicap 50","/ad":"!admin"}</p>
-<div><label><textarea rows="4" cols="50" id="haxShortcut" type="text" placeholder='{"sc1":"shortcut1","sc2":"shortcut2","sc3":"shortcut3"}'></textarea></label>
+<div><label><textarea rows="4" cols="50" id="haxShortcut" type="text" placeholder='{
+"sc1":"shortcut1",
+"sc2":"shortcut2",
+"sc3":"shortcut3"
+}'></textarea></label>
 <br />
 <button id="save">Save Shortcuts</button>
 <button id="enable">Enable all</button>

--- a/newOpt.js
+++ b/newOpt.js
@@ -20,7 +20,11 @@ const defaultSettings = {
 	'haxViewModeConfig': false,
 	'haxRecordHotkey': false,
 	'haxShortcutConfig': false,
-	'haxShortcut': '{"/h1":"/handicap 100","/e1":"/extrapolation 10"}'
+	'haxShortcut':`{
+"/h1":"/handicap 100",
+"/e1":"/extrapolation 10"
+}`
+
 }
 
 const enableAllSettings = {


### PR DESCRIPTION
To enhance readability, I Added end lines for the shortcuts examples and placeholder.

# Before
![image](https://user-images.githubusercontent.com/29176293/68095503-c5f03b80-feb2-11e9-851f-53d68874a47d.png)

# After
![image](https://user-images.githubusercontent.com/29176293/68095510-d7394800-feb2-11e9-84f5-4b7a66ff32fc.png)
