### PR TITLE
Migrated to Chrome's v3 manifest style

### DIFF
--- a/js/content_utility/search_bar.js
+++ b/js/content_utility/search_bar.js
@@ -53,7 +53,7 @@ function createSearch(){
 	var style = document.createElement('link');
 	style.rel = 'stylesheet';
 	style.type = 'text/css';
-	style.href = chrome.extension.getURL("css/filter_button.css");
+	style.href = chrome.runtime.getURL("css/filter_button.css");
 	gameframe.contentWindow.document.head.appendChild(style);
 
 	var newDivWrapper = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "Haxball All-in-one Tool",
-	"version": "0.4.2",
+	"version": "0.4.5",
 	"author": "xenon",
 	"description": "Tools for searching rooms, auto refreshing and joining rooms, admin kick/ban shortcuts, and local-muting of other players",
 	"content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,43 +1,59 @@
 {
-    "manifest_version": 2,
-    "name": "Haxball All-in-one Tool",
-    "version": "0.4.2",
+	"manifest_version": 3,
+	"name": "Haxball All-in-one Tool",
+	"version": "0.4.2",
 	"author": "xenon",
 	"description": "Tools for searching rooms, auto refreshing and joining rooms, admin kick/ban shortcuts, and local-muting of other players",
-    "content_scripts": [
-      {
-        "matches": [
-          "https://*.haxball.com/play*"
-		],
-		"css": ["css/filter_button.css" ],
-		"js": ["js/content_utility/copyright.js", "js/content_utility/search_bar.js", "js/content_utility/auto_join.js",
-			"js/content_utility/admin_kick_or_ban.js", "js/content_utility/toggle_chat.js", "js/content_utility/addon_settings.js",
-			"js/content_utility/transparent_chat.js", "js/content_utility/chat_properties.js", "js/content_utility/emojis.js",
-			 "js/content.js"],
-		"run_at": "document_idle"
-      }
+	"content_scripts": [
+		{
+			"matches": [
+				"https://*.haxball.com/play*"
+			],
+			"css": [
+				"css/filter_button.css"
+			],
+			"js": [
+				"js/content_utility/copyright.js",
+				"js/content_utility/search_bar.js",
+				"js/content_utility/auto_join.js",
+				"js/content_utility/admin_kick_or_ban.js",
+				"js/content_utility/toggle_chat.js",
+				"js/content_utility/addon_settings.js",
+				"js/content_utility/transparent_chat.js",
+				"js/content_utility/chat_properties.js",
+				"js/content_utility/emojis.js",
+				"js/content.js"
+			],
+			"run_at": "document_idle"
+		}
 	],
-	"browser_action": {
+	"action": {
 		"default_icon": "icons/icon.png"
 	},
 	"icons": {
 		"48": "icons/icon.png"
 	},
 	"options_ui": {
-		"page" : "new_option.html",
-		"open_in_tab" : true},
+		"page": "new_option.html",
+		"open_in_tab": true
+	},
 	"background": {
-		"scripts" : ["js/background.js"],
-		"persistent" : true
+		"service_worker": "js/background.js"
 	},
 	"web_accessible_resources": [
-		"emoji_lookup.html",
-		"js/emoji_lookup.js",
-		"css/filter_button.css"
-		
+		{
+			"resources": [
+				"emoji_lookup.html",
+				"js/emoji_lookup.js",
+				"css/filter_button.css"
+			],
+			"matches": [
+				"https://*.haxball.com/*"
+			]
+		}
 	],
 	"permissions": [
-          "notifications",
-		  "storage"
-        ]
-  }
+		"notifications",
+		"storage"
+	]
+}


### PR DESCRIPTION
Updated some of the code according to Chrome's checklist for v2 to v3 Manifest migration.
https://developer.chrome.com/docs/extensions/migrating/checklist/

The addon loads without manifest-related errors now, however some of the addon's features still don't work due to Haxball's recent UI update https://blog.haxball.com/



